### PR TITLE
Accommodate for debug level in Node

### DIFF
--- a/lib/logs.js
+++ b/lib/logs.js
@@ -13,6 +13,10 @@ const log = function (level, isNode, logatim) {
   let message = Array.prototype.slice.call(arguments, 3).join(' ')
   let output = buildOutput(message, isNode)
 
+  if (isNode) {
+    level = level === 'debug' ? 'log' : level;
+  }
+
   isNode ? console[level](output) : console[level].apply(console, output)
 
   return reset(logatim)

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -14,7 +14,7 @@ const log = function (level, isNode, logatim) {
   let output = buildOutput(message, isNode)
 
   if (isNode) {
-    level = level === 'debug' ? 'log' : level;
+    level = level === 'debug' ? 'log' : level
   }
 
   isNode ? console[level](output) : console[level].apply(console, output)


### PR DESCRIPTION
Node doesn't support a `debug` log level. Fall back to standard `log` in order to keep isomorphic capabilities and `debug` level in browsers.
